### PR TITLE
listener: Emit original conn on disown

### DIFF
--- a/graceful/listener/conn_test.go
+++ b/graceful/listener/conn_test.go
@@ -58,7 +58,7 @@ func TestDisownedRead(t *testing.T) {
 	t.Parallel()
 	l, c, wc := singleConn(t, Deadline)
 
-	if err := Disown(wc); err != nil {
+	if _, err := Disown(wc); err != nil {
 		t.Fatalf("unexpected error disowning conn: %v", err)
 	}
 	if err := l.Close(); err != nil {
@@ -95,7 +95,7 @@ func TestDisownedClose(t *testing.T) {
 	t.Parallel()
 	_, c, wc := singleConn(t, Deadline)
 
-	if err := Disown(wc); err != nil {
+	if _, err := Disown(wc); err != nil {
 		t.Fatalf("unexpected error disowning conn: %v", err)
 	}
 	if err := wc.Close(); err != nil {

--- a/graceful/listener/listener.go
+++ b/graceful/listener/listener.go
@@ -148,11 +148,11 @@ var errNotManaged = errors.New("listener: passed net.Conn is not managed by this
 // Disown causes a connection to no longer be tracked by the listener. The
 // passed connection must have been returned by a call to Accept from this
 // listener.
-func Disown(c net.Conn) error {
+func Disown(c net.Conn) (net.Conn, error) {
 	if cn, ok := c.(*conn); ok {
-		return cn.disown()
+		return cn.Conn, cn.disown()
 	}
-	return errNotManaged
+	return nil, errNotManaged
 }
 
 // MarkIdle marks the given connection as being idle, and therefore eligible for

--- a/graceful/listener/listener_test.go
+++ b/graceful/listener/listener_test.go
@@ -79,8 +79,10 @@ func TestDisown(t *testing.T) {
 	t.Parallel()
 	l, c, wc := singleConn(t, Manual)
 
-	if err := Disown(wc); err != nil {
+	if c2, err := Disown(wc); err != nil {
 		t.Fatalf("error disowning connection: %v", err)
+	} else if c2 != c {
+		t.Fatalf("disowned connection is different: %+v %+v", c, c2)
 	}
 	if err := l.CloseIdle(); err != nil {
 		t.Fatalf("error closing idle connections: %v", err)
@@ -126,7 +128,7 @@ func TestDrainAll(t *testing.T) {
 func TestErrors(t *testing.T) {
 	t.Parallel()
 	_, c, wc := singleConn(t, Manual)
-	if err := Disown(c); err == nil {
+	if _, err := Disown(c); err == nil {
 		t.Error("expected error when disowning unmanaged net.Conn")
 	}
 	if err := MarkIdle(c); err == nil {
@@ -136,10 +138,10 @@ func TestErrors(t *testing.T) {
 		t.Error("expected error when marking unmanaged net.Conn in use")
 	}
 
-	if err := Disown(wc); err != nil {
+	if _, err := Disown(wc); err != nil {
 		t.Fatalf("unexpected error disowning socket: %v", err)
 	}
-	if err := Disown(wc); err == nil {
+	if _, err := Disown(wc); err == nil {
 		t.Error("expected error disowning socket twice")
 	}
 }

--- a/graceful/middleware.go
+++ b/graceful/middleware.go
@@ -84,7 +84,7 @@ func (f *fancyWriter) Hijack() (c net.Conn, b *bufio.ReadWriter, e error) {
 	c, b, e = hj.Hijack()
 
 	if e == nil {
-		e = listener.Disown(c)
+		c, e = listener.Disown(c)
 	}
 
 	return

--- a/graceful/serve13.go
+++ b/graceful/serve13.go
@@ -50,7 +50,7 @@ func (c connState) Wrap(nc net.Conn, s http.ConnState) {
 			log.Printf("error marking conn as idle: %v", err)
 		}
 	case http.StateHijacked:
-		if err := listener.Disown(nc); err != nil {
+		if _, err := listener.Disown(nc); err != nil {
 			log.Printf("error disowning hijacked conn: %v", err)
 		}
 	}


### PR DESCRIPTION
This is a breaking API change: listener.Disown now returns two values,
not one.goji